### PR TITLE
increase MaxCallRecvMsgSize from default to 12582912

### DIFF
--- a/cmd/archive/main.go
+++ b/cmd/archive/main.go
@@ -135,7 +135,7 @@ func main() {
 }
 
 func newClient(host string) archive.AccessClient {
-	c, err := archive.NewClient(host, grpc.WithInsecure())
+	c, err := archive.NewClient(host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024 * 1024 * 12))) // default of 4194304 is too small for some dense blocks (e.g. 11172812)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
For some very dense blocks  (e.g. 11172812), the default MaxCallRecvMsgSize of 4194304 (1024 * 1024 * 4) is too small, even when fetching events for just that single block, so this patch sets the MaxCallRecvMsgSize to 12582912 (1024 * 1024 * 12).

I tested this on block 11172812 for MomentMinted events, and it now works when it previously failed with "grpc: received message larger than max (5161233 vs. 4194304)."

I hope that 12582912 should be large enough so that no single block will have so many events that the limit is exceeded.
